### PR TITLE
Callout that impersonation needs (ClusterRole)Binding

### DIFF
--- a/content/en/docs/reference/access-authn-authz/authentication.md
+++ b/content/en/docs/reference/access-authn-authz/authentication.md
@@ -857,7 +857,8 @@ rules:
 ```
 
 {{< note >}}
-Note that impersonation is not namespace scoped - i.e. it requires a `ClusterRole` and `ClusterRoleBinding`, and does not function with `Role` and `RoleBinding`.
+Note that impersonation is not namespace scoped. It requires a `ClusterRole` and `ClusterRoleBinding`,
+and does not function with `Role` and `RoleBinding`.
 {{< /note >}}
 
 ## client-go credential plugins

--- a/content/en/docs/reference/access-authn-authz/authentication.md
+++ b/content/en/docs/reference/access-authn-authz/authentication.md
@@ -857,7 +857,7 @@ rules:
 ```
 
 {{< note >}}
-Impersonating a user (or group) allows you to perform any action as if you were that user (or group);
+Impersonating a user or group allows you to perform any action as if you were that user or group;
 for that reason, impersonation is not namespace scoped.
 If you want to allow impersonation using Kubernetes RBAC, 
 this requires using a `ClusterRole` and a `ClusterRoleBinding`,

--- a/content/en/docs/reference/access-authn-authz/authentication.md
+++ b/content/en/docs/reference/access-authn-authz/authentication.md
@@ -857,7 +857,10 @@ rules:
 ```
 
 {{< note >}}
-Note that impersonation is not namespace scoped. It requires a `ClusterRole` and `ClusterRoleBinding`,
+Impersonating a user (or group) allows you to perform any action as if you were that user (or group);
+for that reason, impersonation is not namespace scoped.
+If you want to allow impersonation using Kubernetes RBAC, 
+this requires using a `ClusterRole` and a `ClusterRoleBinding`,
 and does not function with `Role` and `RoleBinding`.
 {{< /note >}}
 

--- a/content/en/docs/reference/access-authn-authz/authentication.md
+++ b/content/en/docs/reference/access-authn-authz/authentication.md
@@ -856,6 +856,10 @@ rules:
   resourceNames: ["06f6ce97-e2c5-4ab8-7ba5-7654dd08d52b"]
 ```
 
+{{< note >}}
+Note that impersonation is not namespace scoped - i.e. it requires a `ClusterRole` and `ClusterRoleBinding`, and does not function with `Role` and `RoleBinding`.
+{{< /note >}}
+
 ## client-go credential plugins
 
 {{< feature-state for_k8s_version="v1.22" state="stable" >}}

--- a/content/en/docs/reference/access-authn-authz/authentication.md
+++ b/content/en/docs/reference/access-authn-authz/authentication.md
@@ -861,7 +861,7 @@ Impersonating a user or group allows you to perform any action as if you were th
 for that reason, impersonation is not namespace scoped.
 If you want to allow impersonation using Kubernetes RBAC, 
 this requires using a `ClusterRole` and a `ClusterRoleBinding`,
-and does not function with `Role` and `RoleBinding`.
+not a `Role` and `RoleBinding`.
 {{< /note >}}
 
 ## client-go credential plugins


### PR DESCRIPTION
I learned through trial and error that impersonation does not work with `Role` and `RoleBinding` - this was not obvious. It would be good if the docs call this out.